### PR TITLE
Field api interface: dimension bug fix

### DIFF
--- a/src/field_api/ectrans_field_api_mod.F90
+++ b/src/field_api/ectrans_field_api_mod.F90
@@ -531,7 +531,7 @@ DO JFLD = 1, SIZE (YLFL)
         CALL ABOR1("LS not implemeted for FIELD_4RB")
     CLASS DEFAULT
         ! Skip the spectral field as it is not present on this processor
-        ILEN = 1
+        ILEN = 0
   END SELECT
 
   IOFF = IOFF + ILEN

--- a/src/field_api/inv_trans_field_api.F90
+++ b/src/field_api/inv_trans_field_api.F90
@@ -219,7 +219,7 @@ IF (PRESENT(YDFU)) THEN
   ! Output derivatives of vector fields
   IF (PRESENT(YDFU_EW) .AND. PRESENT(YDFV_EW))    THEN
     LLUVDER = .TRUE.
-    IUVDIM = 5
+    IUVDIM = IUVDIM + 2
     ALLOCATE(YLGVU_EW(LG_COUNT(YDFU_EW)))
     ALLOCATE(YLGVV_EW(LG_COUNT(YDFV_EW)))
  ENDIF
@@ -227,14 +227,14 @@ IF (PRESENT(YDFU)) THEN
   ! Output divergence of vector fields
   IF (PRESENT(YDFDIV)) THEN
     LLDIVGP = .TRUE.
-    IUVDIM = 5
+    IUVDIM = IUVDIM + 1
     ALLOCATE(YLGVDIV(LG_COUNT(YDFDIV)))
   ENDIF
 
   ! Output vorticity of vector fields
   IF (PRESENT(YDFVOR)) THEN
     LLVORGP = .TRUE.
-    IUVDIM = 6
+    IUVDIM = IUVDIM + 1
     ALLOCATE(YLGVVOR(LG_COUNT(YDFVOR)))
   ENDIF
 


### PR DESCRIPTION
This PR fixes two bugs discovered during the integration in Arpege:
- the number of field was incremented in `ectrans_field_api_mod.F90` when the field was not present on the CPU
- dimension of temporary arrays in `inv_trans_field_api.F90` were harcoded.


The bug fix has been tested on ATOS with Intel compiler :
- locally with ectrans-benchmark
- locally with the unit-tests
- for one Arpege test case from Davai, with MPI=4
